### PR TITLE
Feature request: Set hostname as well when creating an instance

### DIFF
--- a/qingcloud/resource_qingcloud_instance.go
+++ b/qingcloud/resource_qingcloud_instance.go
@@ -15,6 +15,7 @@ package qingcloud
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	qc "github.com/yunify/qingcloud-sdk-go/service"
 )
@@ -136,6 +137,7 @@ func resourceQingcloudInstanceCreate(d *schema.ResourceData, meta interface{}) e
 	clt := meta.(*QingCloudClient).instance
 	input := new(qc.RunInstancesInput)
 	input.Count = qc.Int(1)
+	input.Hostname, _ = getNamePointer(d)
 	input.InstanceName, _ = getNamePointer(d)
 	input.ImageID = getSetStringPointer(d, resourceInstanceImageID)
 	input.CPU = qc.Int(d.Get(resourceInstanceCPU).(int))


### PR DESCRIPTION
There is a parameter named `hostname` when calling API [RunInstances](https://docs.qingcloud.com/product/api/action/instance/run_instances.html).

I'd like to have it set as well when creating instances in Terraform.
For example:
```hcl
resource "qingcloud_instance" "gateway" {
  name             = "gateway"
  image_id         = "centos75x64"
  keypair_ids      = ["keypair_id"]
  managed_vxnet_id = "vxnet_id"
}
```
Will create an instance named `gateway`, but its hostname is `i-xxxxx`.
It should set instance hostname as `gateway` as well, same behavior as calling `RunInstances` with parameter `hostname`.
