### PR TITLE
An ability to set IPSets as a source for security groups

### DIFF
--- a/qingcloud/resource_qingcloud_security_group_rule.go
+++ b/qingcloud/resource_qingcloud_security_group_rule.go
@@ -31,6 +31,10 @@ func resourceQingcloudSecurityGroupRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			resourceSecurityGroupCidrBlock: {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			resourceSecurityGroupRuleProtocol: {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -62,11 +66,6 @@ func resourceQingcloudSecurityGroupRule() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validatePortString,
-			},
-			resourceSecurityGroupCidrBlock: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateNetworkCIDR,
 			},
 		},
 	}

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -13,54 +13,54 @@ Provides a Security Group Rule resource.
 ## Example Usage
 
 ```
-# Create a new security group.
+# Create a new security group
 resource "qingcloud_security_group" "foo" {
     name = "first_sg"
 }
 # Add a security group rule
-resource "qingcloud_security_group_rule" "foo"{
-    security_group_id= "${qingcloud_security_group.foo.id}"
-    protocol = "tcp"
-    priority = 0
-    action = "accept"
-    direction = 0
-    from_port = 0
-    to_port = 0
+resource "qingcloud_security_group_rule" "foo" {
+  security_group_id = "${qingcloud_security_group.foo.id}"
+  protocol          = "tcp"
+  priority          = 0
+  action            = "accept"
+  direction         = 0
+  from_port         = 0
+  to_port           = 0
 }
 # Add another security group rule
-resource "qingcloud_security_group_rule" "foo1"{
-    security_group_id= "${qingcloud_security_group.foo.id}"
-    protocol = "udp"
-    priority = 1
-    action = "drop"
-    direction = 1
-    from_port = 10
-    to_port = 20
+resource "qingcloud_security_group_rule" "foo1" {
+  security_group_id = "${qingcloud_security_group.foo.id}"
+  protocol          = "udp"
+  priority          = 1
+  action            = "drop"
+  direction         = 1
+  from_port         = 10
+  to_port           = 20
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:
-
 * `security_group_id` - (Required) The id of security group.
-* `name`- (Optional) The name of security group rule.
+* `name` - (Optional) The name of security group rule.
 * `protocol` - (Optional) "tcp", "udp", "icmp", "gre", "esp", "ah", "ipip".
-* `priority`- (Optional) From high to low 0 - 100 , default 0.
-* `action`- (Required) accept/drop.
-* `direction`- (Optional) 0 express down ,1 express up.default 0 .
-* `from_port`- (Optional) If protocol is tcp or udp,this value is start port. else if protocol is icmp,this value is the type of ICMP. The others protocol don't need this value.
-* `to_port`- (Optional) If protocol is tcp or udp,this value is end port. else if protocol is icmp,this value is the code of ICMP. the others protocol don't need this value.
-* `cidr_block`- (Optional) target IP,the Security Group Rule only affect to those IPs .
+* `priority` - (Optional) From high to low 0 - 100, default 0.
+* `action` - (Required) "accept"/"drop".
+* `direction` - (Optional) 0 express down, 1 express up, default 0.
+* `from_port` - (Optional) If protocol is tcp or udp, this value is start port. Else if protocol is icmp, this value is the type of ICMP. The others protocol don't need this value.
+* `to_port` - (Optional) If protocol is tcp or udp, this value is end port. Else if protocol is icmp, this value is the code of ICMP. The others protocol don't need this value.
+* `cidr_block` - (Optional) Source IP or IPSet id. The Security Group Rule affects only those IPs.
 
 ## Attributes Reference
 
 The following attributes are exported:
 * `security_group_id` - The id of security group.
-* `name`- The name of security group rule.
+* `name` - The name of security group rule.
 * `protocol` - "tcp", "udp", "icmp", "gre", "esp", "ah", "ipip".
-* `priority`- From high to low 0 - 100 , default 0.
-* `action`- accept/drop.
-* `direction`- 0 express down ,1 express up.default 0 .
-* `from_port`- If protocol is tcp or udp,this value is start port. else if protocol is icmp,this value is the type of ICMP. The others protocol don't need this value.
-* `to_port`- If protocol is tcp or udp,this value is end port. else if protocol is icmp,this value is the code of ICMP. the others protocol don't need this value.
-* `cidr_block`- target IP,the Security Group Rule only affect to those IPs .
+* `priority` - From high to low 0 - 100, default 0.
+* `action` - "accept"/"drop".
+* `direction` - 0 express down, 1 express up, default 0.
+* `from_port` - If protocol is tcp or udp, this value is start port. Else if protocol is icmp, this value is the type of ICMP. The others protocol don't need this value.
+* `to_port` - If protocol is tcp or udp, this value is end port. Else if protocol is icmp, this value is the code of ICMP. The others protocol don't need this value.
+* `cidr_block` - Source IP or IPSet id. The Security Group Rule affects only those IPs.


### PR DESCRIPTION
Adding an ability to set IPSets for the Source IP filed under Security Groups. 

There is no need to check it from the module side as validations are performed by API, so `ValidateFunc` was removed.

In addition, improving documentation for Security Group Rules.